### PR TITLE
Refactoring to support detection of absent `expect_connect`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ refresh_venv: .make/venv_refreshed
 .PHONY: test
 test: | refresh_venv
 	scripts/run_tests.sh --log-cli-level INFO tests
-	#scripts/run_tests.sh --log-cli-level DEBUG tests/test_mocktcp.py::test_early_error_doesnt_hang
+
+.PHONY: testlf
+testlf: | refresh_venv
+	scripts/run_tests.sh --log-cli-level INFO --last-failed tests
 
 .PHONY: distclean
 distclean:


### PR DESCRIPTION
* Added `actual_events_queue`
* Changed `__call__` to `evaluate` on expecation objects
* Added `server_action` to expectation objects
* Added `server_action_task`
* Added `timeout` param to `expect_bytes`